### PR TITLE
Change setRoot in RootHolder to comply with naming convention

### DIFF
--- a/src/main/java/io/codenotary/immudb4j/FileRootHolder.java
+++ b/src/main/java/io/codenotary/immudb4j/FileRootHolder.java
@@ -66,14 +66,14 @@ public class FileRootHolder implements RootHolder {
   }
 
   @Override
-  public synchronized void SetRoot(Root root) {
+  public synchronized void setRoot(Root root) {
     Root currentRoot = rootHolder.getRoot(root.getDatabase());
 
     if (currentRoot != null && currentRoot.getIndex() >= root.getIndex()) {
       return;
     }
 
-    rootHolder.SetRoot(root);
+    rootHolder.setRoot(root);
 
     Path newRootHolderFile = rootsFolder.resolve("root_" + System.nanoTime());
 

--- a/src/main/java/io/codenotary/immudb4j/ImmuClient.java
+++ b/src/main/java/io/codenotary/immudb4j/ImmuClient.java
@@ -174,7 +174,7 @@ public class ImmuClient {
       Empty empty = com.google.protobuf.Empty.getDefaultInstance();
       ImmudbProto.Root r = getStub().currentRoot(empty);
       Root root = new Root(activeDatabase, r.getIndex(), r.getRoot().toByteArray());
-      rootHolder.SetRoot(root);
+      rootHolder.setRoot(root);
     }
     return rootHolder.getRoot(activeDatabase);
   }
@@ -254,7 +254,7 @@ public class ImmuClient {
 
     CryptoUtils.verify(proof, safeItem.getItem(), root);
 
-    rootHolder.SetRoot(new Root(activeDatabase, proof.getAt(), proof.getRoot().toByteArray()));
+    rootHolder.setRoot(new Root(activeDatabase, proof.getAt(), proof.getRoot().toByteArray()));
 
     return safeItem.getItem().getValue().toByteArray();
   }
@@ -291,7 +291,7 @@ public class ImmuClient {
 
     CryptoUtils.verify(proof, item, root);
 
-    rootHolder.SetRoot(new Root(activeDatabase, proof.getAt(), proof.getRoot().toByteArray()));
+    rootHolder.setRoot(new Root(activeDatabase, proof.getAt(), proof.getRoot().toByteArray()));
   }
 
   public void setAll(KVList kvList) {

--- a/src/main/java/io/codenotary/immudb4j/RootHolder.java
+++ b/src/main/java/io/codenotary/immudb4j/RootHolder.java
@@ -21,6 +21,6 @@ public interface RootHolder {
 
   Root getRoot(String database);
 
-  void SetRoot(Root root);
+  void setRoot(Root root);
 
 }

--- a/src/main/java/io/codenotary/immudb4j/SerializableRootHolder.java
+++ b/src/main/java/io/codenotary/immudb4j/SerializableRootHolder.java
@@ -48,7 +48,7 @@ public class SerializableRootHolder implements RootHolder {
   }
 
   @Override
-  public void SetRoot(Root root) {
+  public void setRoot(Root root) {
     this.rootMap.put(root.getDatabase(),root);
   }
 


### PR DESCRIPTION
This PR uses the correct naming convention for the RootHolder.SetRoot method