### PR TITLE
fix: initialize sessionHeartBeatTimer as daemon.

### DIFF
--- a/src/main/java/io/codenotary/immudb4j/ImmuClient.java
+++ b/src/main/java/io/codenotary/immudb4j/ImmuClient.java
@@ -148,7 +148,7 @@ public class ImmuClient {
 
         session = new Session(resp.getSessionID(), database);
 
-        sessionHeartBeat = new Timer();
+        sessionHeartBeat = new Timer(true);
 
         sessionHeartBeat.schedule(new TimerTask() {
             @Override


### PR DESCRIPTION
Running the session heartbeat without setting it as a daemon will prolong the application lifetime indefinitely unless closeSession() is called.