### PR TITLE
update ImmuClientverifiedGet  to return  `VerifiableEntry` instead of`Entry`

### DIFF
--- a/src/main/java/io/codenotary/immudb4j/Entry.java
+++ b/src/main/java/io/codenotary/immudb4j/Entry.java
@@ -18,43 +18,52 @@ package io.codenotary.immudb4j;
 import io.codenotary.immudb.ImmudbProto;
 
 public class Entry {
-    private long tx;
+    private final long tx;
 
-    private byte[] key;
+    private final byte[] key;
 
-    private byte[] value;
+    private final byte[] value;
 
-    private KVMetadata metadata;
+    private final KVMetadata metadata;
 
-    private Reference referencedBy;
+    private final Reference referencedBy;
 
-    private long revision;
-
-    private Entry() {}
+    private final long revision;
 
     public Entry(byte[] key, byte[] value) {
+        this(0L, key, value, null, null, 0L);
+    }
+
+    Entry(long tx,
+          byte[] key,
+          byte[] value,
+          KVMetadata metadata,
+          Reference referencedBy,
+          long revision) {
+        this.tx = tx;
         this.key = key;
         this.value = value;
+        this.metadata = metadata;
+        this.referencedBy = referencedBy;
+        this.revision = revision;
     }
 
     public static Entry valueOf(ImmudbProto.Entry e) {
-        final Entry entry = new Entry();
 
-        entry.tx = e.getTx();
-        entry.key = e.getKey().toByteArray();
-        entry.value = e.getValue().toByteArray();
-
+        KVMetadata metadata = null;
         if (e.hasMetadata()) {
-            entry.metadata = KVMetadata.valueOf(e.getMetadata());
+            metadata = KVMetadata.valueOf(e.getMetadata());
         }
-
+        Reference referencedBy = null;
         if (e.hasReferencedBy()) {
-            entry.referencedBy = Reference.valueOf(e.getReferencedBy());
+            referencedBy = Reference.valueOf(e.getReferencedBy());
         }
-
-        entry.revision = e.getRevision();
-
-        return entry;
+        return new Entry(e.getTx(),
+                e.getKey().toByteArray(),
+                e.getValue().toByteArray(),
+                metadata,
+                referencedBy,
+                e.getRevision());
     }
 
     public long getTx() {

--- a/src/main/java/io/codenotary/immudb4j/ImmuClient.java
+++ b/src/main/java/io/codenotary/immudb4j/ImmuClient.java
@@ -989,7 +989,7 @@ public class ImmuClient {
 
         stateHolder.setState(newState);
 
-        return Entry.valueOf(vEntry.getEntry());
+        return VerifiableEntry.valueOf(vEntry);
     }
 
     //

--- a/src/main/java/io/codenotary/immudb4j/ImmuClient.java
+++ b/src/main/java/io/codenotary/immudb4j/ImmuClient.java
@@ -754,8 +754,8 @@ public class ImmuClient {
     /**
      * @param key the keys to look for
      * @return the latest entry associated to the provided key. Equivalent to
-     *         {@link #get(String) get} but with additional
-     *         server-provided proof validation.
+     *         {@link #get(String) get} but with additional server-provided proof validation.
+     *         Returned object can be cast to {@link VerifiableEntry} instance.
      * @throws KeyNotFoundException  if the key is not found
      * @throws VerificationException if proof validation fails
      */
@@ -768,6 +768,7 @@ public class ImmuClient {
      * @return the latest entry associated to the provided key. Equivalent to
      *         {@link #get(byte[]) get} but with additional
      *         server-provided proof validation.
+     *         Returned object can be cast to {@link VerifiableEntry} instance.
      * @throws KeyNotFoundException  if the key is not found
      * @throws VerificationException if proof validation fails
      */
@@ -779,9 +780,9 @@ public class ImmuClient {
      * @param key the key to look for
      * @param tx  the transaction at which the associated entry is expected to be
      * @return the entry associated to the provided key and transaction. Equivalent
-     *         to
-     *         {@link #getAtTx(String, long) getAtTx} but with additional
+     *         to {@link #getAtTx(String, long) getAtTx} but with additional
      *         server-provided proof validation.
+     *         Returned object can be cast to {@link VerifiableEntry} instance.
      * @throws KeyNotFoundException  if the key is not found
      * @throws VerificationException if proof validation fails
      */
@@ -793,9 +794,9 @@ public class ImmuClient {
      * @param key the key to look for
      * @param tx  the transaction at which the associated entry is expected to be
      * @return the entry associated to the provided key and transaction. Equivalent
-     *         to
-     *         {@link #getAtTx(byte[], long) getAtTx} but with additional
+     *         to {@link #getAtTx(byte[], long) getAtTx} but with additional
      *         server-provided proof validation.
+     *         Returned object can be cast to {@link VerifiableEntry} instance.
      * @throws KeyNotFoundException  if the key is not found
      * @throws VerificationException if proof validation fails
      */
@@ -820,9 +821,9 @@ public class ImmuClient {
      *            retrieved
      * @return the latest indexed entry associated the to provided key. Ensuring the
      *         indexing has already be completed up to the specified transaction.
-     *         Equivalent to
-     *         {@link #getSinceTx(String, long) getSinceTx} but with additional
+     *         Equivalent to {@link #getSinceTx(String, long) getSinceTx} but with additional
      *         server-provided proof validation.
+     *         Returned object can be cast to {@link VerifiableEntry} instance.
      * @throws KeyNotFoundException  if the key is not found
      * @throws VerificationException if proof validation fails
      */
@@ -840,9 +841,9 @@ public class ImmuClient {
      *            retrieved
      * @return the latest indexed entry associated the to provided key. Ensuring the
      *         indexing has already be completed up to the specified transaction.
-     *         Equivalent to
-     *         {@link #getSinceTx(byte[], long) getSinceTx} but with additional
+     *         Equivalent to {@link #getSinceTx(byte[], long) getSinceTx} but with additional
      *         server-provided proof validation.
+     *         Returned object can be cast to {@link VerifiableEntry} instance.
      * @throws KeyNotFoundException  if the key is not found
      * @throws VerificationException if proof validation fails
      */
@@ -864,8 +865,8 @@ public class ImmuClient {
      * @param rev the specific revision
      * @return the specific revision for given key. Equivalent to
      *         {@link #getAtRevision(String, long) getAtRevision} but with
-     *         additional
-     *         server-provided proof validation.
+     *         additional server-provided proof validation.
+     *         Returned object can be cast to {@link VerifiableEntry} instance.
      * @throws KeyNotFoundException  if the key is not found
      * @throws VerificationException if proof validation fails
      */
@@ -878,8 +879,8 @@ public class ImmuClient {
      * @param rev the specific revision
      * @return the specific revision for given key. Equivalent to
      *         {@link #getAtRevision(byte[], long) getAtRevision} but with
-     *         additional
-     *         server-provided proof validation.
+     *         additional server-provided proof validation.
+     *         Returned object can be cast to {@link VerifiableEntry} instance.
      * @throws KeyNotFoundException  if the key is not found
      * @throws VerificationException if proof validation fails
      */
@@ -989,7 +990,11 @@ public class ImmuClient {
 
         stateHolder.setState(newState);
 
-        return VerifiableEntry.valueOf(vEntry);
+        return VerifiableEntry.newBuilder()
+                .withEntry(entry)
+                .withInclusionProof(inclusionProof)
+                .withVerifiableTx(VerifiableTx.valueOf(vEntry.getVerifiableTx()))
+                .build();
     }
 
     //

--- a/src/main/java/io/codenotary/immudb4j/Signature.java
+++ b/src/main/java/io/codenotary/immudb4j/Signature.java
@@ -1,0 +1,42 @@
+/*
+Copyright 2022 CodeNotary, Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package io.codenotary.immudb4j;
+
+import io.codenotary.immudb.ImmudbProto;
+
+public class Signature {
+    private final byte[] publicKey;
+    private final byte[] signature;
+
+    private Signature(byte[] publicKey, byte[] signature) {
+        this.publicKey = publicKey;
+        this.signature = signature;
+    }
+
+    public static Signature valueOf(ImmudbProto.Signature signature) {
+        return new Signature(
+                signature.getPublicKey().toByteArray(),
+                signature.getSignature().toByteArray());
+    }
+
+    public byte[] getPublicKey() {
+        return publicKey;
+    }
+
+    public byte[] getSignature() {
+        return signature;
+    }
+}

--- a/src/main/java/io/codenotary/immudb4j/VerifiableEntry.java
+++ b/src/main/java/io/codenotary/immudb4j/VerifiableEntry.java
@@ -1,0 +1,93 @@
+/*
+Copyright 2022 CodeNotary, Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package io.codenotary.immudb4j;
+
+import io.codenotary.immudb.ImmudbProto;
+import io.codenotary.immudb4j.crypto.InclusionProof;
+import io.codenotary.immudb4j.exceptions.VerificationException;
+
+public class VerifiableEntry extends Entry {
+    private final Entry entry;
+    private final VerifiableTx verifiableTx;
+    private final InclusionProof inclusionProof;
+
+    private VerifiableEntry(Entry entry, VerifiableTx verifiableTx, InclusionProof inclusionProof) {
+        super(entry.getKey(), entry.getValue());
+        this.entry = entry;
+        this.verifiableTx = verifiableTx;
+        this.inclusionProof = inclusionProof;
+    }
+
+    public static VerifiableEntry valueOf(ImmudbProto.VerifiableEntry verifiableEntry) throws VerificationException {
+        return new VerifiableEntry(
+                Entry.valueOf(verifiableEntry.getEntry()),
+                VerifiableTx.valueOf(verifiableEntry.getVerifiableTx()),
+                InclusionProof.valueOf(verifiableEntry.getInclusionProof())
+        );
+    }
+
+    public Entry getEntry() {
+        return entry;
+    }
+
+    public VerifiableTx getVerifiableTx() {
+        return verifiableTx;
+    }
+
+    public InclusionProof getInclusionProof() {
+        return inclusionProof;
+    }
+
+    @Override
+    public long getTx() {
+        return entry.getTx();
+    }
+
+    @Override
+    public byte[] getKey() {
+        return entry.getKey();
+    }
+
+    @Override
+    public byte[] getValue() {
+        return entry.getValue();
+    }
+
+    @Override
+    public KVMetadata getMetadata() {
+        return entry.getMetadata();
+    }
+
+    @Override
+    public Reference getReferenceBy() {
+        return entry.getReferenceBy();
+    }
+
+    @Override
+    public long getRevision() {
+        return entry.getRevision();
+    }
+
+    @Override
+    public byte[] getEncodedKey() {
+        return entry.getEncodedKey();
+    }
+
+    @Override
+    public byte[] digestFor(int version) {
+        return entry.digestFor(version);
+    }
+}

--- a/src/main/java/io/codenotary/immudb4j/VerifiableEntry.java
+++ b/src/main/java/io/codenotary/immudb4j/VerifiableEntry.java
@@ -15,9 +15,9 @@ limitations under the License.
 */
 package io.codenotary.immudb4j;
 
-import io.codenotary.immudb.ImmudbProto;
 import io.codenotary.immudb4j.crypto.InclusionProof;
-import io.codenotary.immudb4j.exceptions.VerificationException;
+
+import java.util.Objects;
 
 public class VerifiableEntry extends Entry {
     private final Entry entry;
@@ -25,18 +25,19 @@ public class VerifiableEntry extends Entry {
     private final InclusionProof inclusionProof;
 
     private VerifiableEntry(Entry entry, VerifiableTx verifiableTx, InclusionProof inclusionProof) {
-        super(entry.getKey(), entry.getValue());
+        super(entry.getTx(),
+                entry.getKey(),
+                entry.getValue(),
+                entry.getMetadata(),
+                entry.getReferenceBy(),
+                entry.getRevision());
         this.entry = entry;
         this.verifiableTx = verifiableTx;
         this.inclusionProof = inclusionProof;
     }
 
-    public static VerifiableEntry valueOf(ImmudbProto.VerifiableEntry verifiableEntry) throws VerificationException {
-        return new VerifiableEntry(
-                Entry.valueOf(verifiableEntry.getEntry()),
-                VerifiableTx.valueOf(verifiableEntry.getVerifiableTx()),
-                InclusionProof.valueOf(verifiableEntry.getInclusionProof())
-        );
+    public static Builder newBuilder() {
+        return new Builder();
     }
 
     public Entry getEntry() {
@@ -51,43 +52,36 @@ public class VerifiableEntry extends Entry {
         return inclusionProof;
     }
 
-    @Override
-    public long getTx() {
-        return entry.getTx();
+    public static class Builder {
+        private Entry entry;
+        private VerifiableTx verifiableTx;
+        private InclusionProof inclusionProof;
+
+        private Builder() {
+
+        }
+
+        public Builder withEntry(Entry entry) {
+            this.entry = entry;
+            return this;
+        }
+
+        public Builder withVerifiableTx(VerifiableTx verifiableTx) {
+            this.verifiableTx = verifiableTx;
+            return this;
+        }
+
+        public Builder withInclusionProof(InclusionProof inclusionProof) {
+            this.inclusionProof = inclusionProof;
+            return this;
+        }
+
+        public VerifiableEntry build() {
+            Objects.requireNonNull(this.entry, "'entry' cant be null");
+            Objects.requireNonNull(this.verifiableTx, "'verifiableTx' cant be null");
+            Objects.requireNonNull(this.inclusionProof, "'inclusionProof' cant be null");
+            return new VerifiableEntry(this.entry, this.verifiableTx, this.inclusionProof);
+        }
     }
 
-    @Override
-    public byte[] getKey() {
-        return entry.getKey();
-    }
-
-    @Override
-    public byte[] getValue() {
-        return entry.getValue();
-    }
-
-    @Override
-    public KVMetadata getMetadata() {
-        return entry.getMetadata();
-    }
-
-    @Override
-    public Reference getReferenceBy() {
-        return entry.getReferenceBy();
-    }
-
-    @Override
-    public long getRevision() {
-        return entry.getRevision();
-    }
-
-    @Override
-    public byte[] getEncodedKey() {
-        return entry.getEncodedKey();
-    }
-
-    @Override
-    public byte[] digestFor(int version) {
-        return entry.digestFor(version);
-    }
 }

--- a/src/main/java/io/codenotary/immudb4j/VerifiableTx.java
+++ b/src/main/java/io/codenotary/immudb4j/VerifiableTx.java
@@ -1,0 +1,60 @@
+/*
+Copyright 2022 CodeNotary, Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package io.codenotary.immudb4j;
+
+import io.codenotary.immudb.ImmudbProto;
+import io.codenotary.immudb4j.crypto.DualProof;
+import io.codenotary.immudb4j.exceptions.VerificationException;
+
+import java.security.NoSuchAlgorithmException;
+
+public class VerifiableTx {
+    private final Tx tx;
+    private final DualProof dualProof;
+    private final Signature signature;
+
+    private VerifiableTx(Tx tx, DualProof dualProof, Signature signature) {
+        this.tx = tx;
+        this.dualProof = dualProof;
+        this.signature = signature;
+    }
+
+    public static VerifiableTx valueOf(ImmudbProto.VerifiableTx verifiableTx) throws VerificationException {
+        Tx innerTx;
+        try {
+            innerTx = Tx.valueOf(verifiableTx.getTx());
+        } catch (NoSuchAlgorithmException e) {
+            throw new VerificationException("Failed to build VerifiableTx",e);
+        }
+        return new VerifiableTx(
+                innerTx,
+                DualProof.valueOf(verifiableTx.getDualProof()),
+                Signature.valueOf(verifiableTx.getSignature())
+        );
+    }
+
+    public Tx getTx() {
+        return tx;
+    }
+
+    public DualProof getDualProof() {
+        return dualProof;
+    }
+
+    public Signature getSignature() {
+        return signature;
+    }
+}

--- a/src/test/java/io/codenotary/immudb4j/VerifiedSetAndGetTest.java
+++ b/src/test/java/io/codenotary/immudb4j/VerifiedSetAndGetTest.java
@@ -192,4 +192,73 @@ public class VerifiedSetAndGetTest extends ImmuClientIntegrationTest {
         immuClient.closeSession();
     }
 
+    @Test(testName = "verifyGet returns a valid VerifiableEntry")
+    public void t7() {
+        immuClient.openSession("defaultdb", "immudb", "immudb");
+
+        byte[] key = "verifyGet1".getBytes(StandardCharsets.UTF_8);
+        byte[] val = "test-verify-get".getBytes(StandardCharsets.UTF_8);
+        try {
+            TxHeader txHdr = immuClient.verifiedSet(key, val);
+            Assert.assertNotNull(txHdr, "The result of verifiedSet must not be null.");
+        } catch (VerificationException e) {
+            Assert.fail("Failed at verifiedSet. Cause: " + e.getMessage(), e);
+        }
+
+        try {
+            VerifiableEntry vEntry = (VerifiableEntry) immuClient.verifiedGet(key);
+            Assert.assertNotNull(vEntry.getEntry());
+            Assert.assertNotNull(vEntry.getVerifiableTx());
+            Assert.assertNotNull(vEntry.getInclusionProof());
+            Assert.assertNotEquals(vEntry.getTx(), 0);
+            Assert.assertEquals(vEntry.getKey(), key);
+            Assert.assertEquals(vEntry.getValue(), val);
+            Assert.assertNull(vEntry.getMetadata());
+            Assert.assertNull(vEntry.getReferenceBy());
+            Assert.assertNotEquals(vEntry.getRevision(), 0);
+            Assert.assertNotNull(vEntry.getEncodedKey());
+            Assert.assertNotNull(vEntry.digestFor(1));
+
+        } catch (VerificationException e) {
+            Assert.fail("Failed at verifiedGet. Cause: " + e.getMessage(), e);
+        } catch (ClassCastException e) {
+            Assert.fail("verifiedGet result is not instance of :" + VerifiableEntry.class.getName(), e);
+        }
+        immuClient.closeSession();
+    }
+
+    @Test(testName = "VerifiableEntry returned by verifiedGet contains a valid VerifiableTx")
+    public void t8() {
+        immuClient.openSession("defaultdb", "immudb", "immudb");
+
+        byte[] key = "verifyGet1".getBytes(StandardCharsets.UTF_8);
+        byte[] val = "test-verify-get".getBytes(StandardCharsets.UTF_8);
+        try {
+            //first save
+            TxHeader txHdr = immuClient.verifiedSet(key, val);
+            Assert.assertNotNull(txHdr, "The result of first verifiedSet must not be null.");
+        } catch (VerificationException e) {
+            Assert.fail("Failed at verifiedSet. Cause: " + e.getMessage(), e);
+        }
+
+        try {
+            VerifiableEntry vEntry = (VerifiableEntry) immuClient.verifiedGet(key);
+            Assert.assertNotNull(vEntry.getEntry());
+            VerifiableTx verifiableTx = vEntry.getVerifiableTx();
+            Assert.assertNotNull(verifiableTx);
+            Assert.assertNotNull(verifiableTx.getTx());
+            Assert.assertNotNull(verifiableTx.getDualProof());
+            Signature signature = verifiableTx.getSignature();
+            Assert.assertNotNull(signature);
+            Assert.assertNotNull(signature.getSignature());
+            Assert.assertNotNull(signature.getPublicKey());
+
+        } catch (VerificationException e) {
+            Assert.fail("Failed at verifiedGet. Cause: " + e.getMessage(), e);
+        } catch (ClassCastException e) {
+            Assert.fail("verifiedGet result is not instance of :" + VerifiableEntry.class.getName(), e);
+        }
+        immuClient.closeSession();
+    }
+
 }


### PR DESCRIPTION
Hello
Current implementation of `rpc VerifiableGet` returns instance of type `VerifiableEntry`. At same time `ImmuClient.verifiedGet` return instance of type `Entry`. 
Considering fact that that  `VerifiableEntry` is a more complex class than `Entry`, ex: it contains more details about transaction  in `VerifiableTx`, I have added new classes `VerifiableEntry`, `VerifiableTx` which now match rpc call response and update `ImmuClient.verifiedGet` to return `VerifiableEntry` instance.
In order to avoid impact on existing library users, `VerifiableEntry` extends `Entry` class.

Artiom