### PR TITLE
Bump protoc to 3.25.5 and grpc to 1.68.1 (CVE-2024-7254)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,8 +45,10 @@ version = '1.0.1'
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
-def protocVersion = '3.19.4'
-def grpcVersion = '1.55.1'
+// Bump protoc/grpc so the generated stubs depend on protobuf-java 3.25.5 (pulled transitively via
+// grpc 1.68.1), fixing CVE-2024-7254 (protobuf recursion DoS) in the generated ImmudbProto types.
+def protocVersion = '3.25.5'
+def grpcVersion = '1.68.1'
 
 protobuf {
     protoc {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.4-bin.zip


### PR DESCRIPTION
## What

Raises the protobuf/gRPC toolchain so the generated `ImmudbProto` stubs no longer depend on a `protobuf-java` version affected by [CVE-2024-7254](https://nvd.nist.gov/vuln/detail/CVE-2024-7254) (unbounded recursion / stack-overflow DoS while parsing).

- `protoc` 3.19.4 → **3.25.5**
- `grpc` 1.55.1 → **1.68.1**

With grpc 1.68.1 the transitive `protobuf-java` becomes **3.25.5**, which is on the patched line (the fix landed in 3.25.5 / 4.27.5 / 4.28.2). The jump stays within protobuf-java 3.x, so the generated-code API is unchanged.

## Why the Gradle wrapper bump

grpc 1.68.1 pulls guava 33, whose `android`/`jre` module variants are only auto-resolved by Gradle 7+. On Gradle 6.x the build fails with *"Cannot choose between androidRuntimeElements and jreRuntimeElements"*. The wrapper is therefore bumped **6.3 → 7.6.4**; `protobuf-gradle-plugin` 0.8.18 continues to work on Gradle 7.

## Testing

- `./gradlew build` — compiles, regenerates the stubs with protoc 3.25.5, unit tests green.
- Full unit-test suite (60/60) passes against a real `immudb 1.11.1`.

No source or API changes; this is purely a build-toolchain bump.